### PR TITLE
Allow for spaces in install path

### DIFF
--- a/FactorioServerLuancher/Download.cs
+++ b/FactorioServerLuancher/Download.cs
@@ -17,26 +17,51 @@ namespace FactorioServerLauncher
         public static Process DownloadFactorio = new Process();
 
         [PermissionSet(SecurityAction.Demand, Name = "FullTrust")]
-        public static void Start(string Path, string Username="", string Password="")
+        public static void Start(string Path, string Username = "", string Password = "")
         {
+            string tempPath = System.IO.Path.GetTempPath();
             string AnonumysLogin = "";
             if (Username != "" && Password != "")
-                AnonumysLogin = "+login " + Username + " " + Password;
+                AnonumysLogin = "login " + Username + " " + Password;
 
-            var StartArguments = AnonumysLogin + " +force_install_dir " + Settings.factorioInstallPath + " +app_update "+ Settings.appId.ToString() +" validate +quit";
-            ProcessStartInfo startInfo = new ProcessStartInfo();
-            startInfo.WindowStyle = ProcessWindowStyle.Normal;
-            startInfo.Verb = "runas";
+            CreateSteamCmdScript(AnonumysLogin);
 
-            startInfo.FileName = Path + @"\steamcmd.exe";
-            startInfo.Arguments = StartArguments;
-            startInfo.WorkingDirectory = Path;
-            startInfo.CreateNoWindow = false;
-            startInfo.RedirectStandardInput = false;
-            startInfo.RedirectStandardOutput = false;
-            startInfo.UseShellExecute = true;
+            var StartArguments = "+runscript " + tempPath + "steamcmd.txt";
+            ProcessStartInfo startInfo = new ProcessStartInfo
+            {
+                WindowStyle = ProcessWindowStyle.Normal,
+                Verb = "runas",
+
+                FileName = Path + @"\steamcmd.exe",
+                Arguments = StartArguments,
+                WorkingDirectory = Path,
+                CreateNoWindow = false,
+                RedirectStandardInput = false,
+                RedirectStandardOutput = false,
+                UseShellExecute = true
+            };
 
             DownloadFactorio = Process.Start(startInfo);
+            DownloadFactorio.WaitForExit();
+
+            if (File.Exists(tempPath + "steamcmd.txt"))
+            {
+                File.Delete(tempPath + "steamcmd.txt");
+            }
+        }
+
+        private static void CreateSteamCmdScript(string login)
+        {
+            string[] scriptLines = {
+                login,
+                "force_install_dir \"" + Settings.factorioInstallPath + "\"",
+                "app_update "+ Settings.appId.ToString(),
+                "quit"
+            };
+
+            string tempPath = Path.GetTempPath();
+
+            System.IO.File.WriteAllLines(tempPath + "steamcmd.txt", scriptLines);
         }
 
     }


### PR DESCRIPTION
Use steamcmd script instead of command line arguments to allow for spaces in install path. Currently an install folder of "C:\Program Files\Steam" will try to install to "C:\program\steam" or will fail entirely due to a steamcmd quirk outlined at https://github.com/ValveSoftware/Source-1-Games/issues/350 using a script works around this issue.